### PR TITLE
New weights

### DIFF
--- a/docs/studies/vae_retraining/README.md
+++ b/docs/studies/vae_retraining/README.md
@@ -64,6 +64,11 @@ The weight files are ignored by Git. Uploading/replacing the public default
 weights is a separate release action; code should be merged and both
 ``starccato_jax`` and ``starccato_lvk`` tested before publishing them.
 
+For v0.3.0 the weights are published under versioned URLs at
+``weights/starcatto_jax/v0.3.0/``. The unversioned v0.2.x files remain in place
+so older installations never attempt to load artifacts with the new metadata
+and decoder contract.
+
 ## Cheap NUTS initialization
 
 ``starccato_lvk.analysis.jim_likelihood.find_multistart_map`` performs bounded

--- a/scripts/push_defaults_online.sh
+++ b/scripts/push_defaults_online.sh
@@ -1,11 +1,35 @@
-git clone git@github.com:starccato/data.git
-cp out_ccsne/model.h5 data/weights/starcatto_jax/ccsne_vae.h5
-cp out_blip/model.h5 data/weights/starcatto_jax/blip_vae.h5
-cd data
-git add weights/starcatto_jax/*.h5
-git commit -m "Update default VAE weights for starccato_jax v$(python -c 'import starccato_jax;print(starccato_jax.__version__)')"
-git push
-git filter-repo --force --invert-paths --path weights/starcatto_jax/ccsne_vae_z32.h5 --path weights/starcatto_jax/blip_vae_z32.h5
-git push --force
-cd ..
-rm -rf data
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 VERSION (for example: v0.3.0)" >&2
+  exit 2
+fi
+
+version=$1
+repo_root=$(git rev-parse --show-toplevel)
+ccsne_model="$repo_root/out_ccsne/model.h5"
+blip_model="$repo_root/out_blip/model.h5"
+
+for model in "$ccsne_model" "$blip_model"; do
+  if [[ ! -f "$model" ]]; then
+    echo "missing trained model: $model" >&2
+    exit 1
+  fi
+done
+
+clone_dir=$(mktemp -d /tmp/starccato-data-weights.XXXXXX)
+trap 'rm -rf "$clone_dir"' EXIT
+git clone git@github.com:starccato/data.git "$clone_dir"
+
+destination="$clone_dir/weights/starcatto_jax/$version"
+mkdir -p "$destination"
+cp "$ccsne_model" "$destination/ccsne_vae.h5"
+cp "$blip_model" "$destination/blip_vae.h5"
+
+git -C "$clone_dir" add \
+  "weights/starcatto_jax/$version/ccsne_vae.h5" \
+  "weights/starcatto_jax/$version/blip_vae.h5"
+git -C "$clone_dir" commit -m \
+  "feat: add starccato_jax $version VAE weights"
+git -C "$clone_dir" push origin main

--- a/src/starccato_jax/data/urls.py
+++ b/src/starccato_jax/data/urls.py
@@ -6,5 +6,8 @@ CCSNE_PARAMETERS_URL = f"{_ROOT_URL}/training/richers_1764_parameters.csv"
 BLIP_SIGNALS_URL = f"{_ROOT_URL}/training/gwspy_glitches.dat.zip"
 ALIGNED_DATA_URL = f"{_ROOT_URL}/training/aligned_data.h5"
 
-BLIP_WEIGHTS_URL = f"{_ROOT_URL}/weights/starcatto_jax/blip_vae.h5"
-CCSNE_WEIGHTS_URL = f"{_ROOT_URL}/weights/starcatto_jax/ccsne_vae.h5"
+_WEIGHTS_VERSION = "v0.3.0"
+_WEIGHTS_ROOT = f"{_ROOT_URL}/weights/starcatto_jax/{_WEIGHTS_VERSION}"
+
+BLIP_WEIGHTS_URL = f"{_WEIGHTS_ROOT}/blip_vae.h5"
+CCSNE_WEIGHTS_URL = f"{_WEIGHTS_ROOT}/ccsne_vae.h5"


### PR DESCRIPTION
The retrained VAEs store the new decoder-normalization metadata and enforce a zero-mean, unit-RMS waveform contract. Replacing the existing unversioned files would make older starccato_jax installations attempt to load metadata they do not understand. Versioned URLs keep v0.2.x compatible while allowing this conventional feat commit to release v0.3.0.